### PR TITLE
CSS: Fix container -> full width container

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 
 <body>
 
-    <div class="container">
+    <div class="full-width-container">
         <!-- main -->
         <section id="main">
             <div class="flex flex-col">

--- a/style.css
+++ b/style.css
@@ -13,13 +13,13 @@ body {
 body ::-webkit-scrollbar {
   display: none;
 }
-body .container {
+body .full-width-container {
   width: 100%;
   height: 100%;
   scroll-snap-type: y proximity;
   overflow-y: scroll;
 }
-body .container section {
+body .full-width-container section {
   width: 100vw;
   height: 100vh;
   scroll-snap-align: start;
@@ -27,19 +27,19 @@ body .container section {
   align-items: center;
   justify-content: center;
 }
-body .container section:nth-of-type(1) {
+body .full-width-container section:nth-of-type(1) {
   background-color: black;
   color: white;
 }
-body .container section:nth-of-type(2) {
+body .full-width-container section:nth-of-type(2) {
   background-color: white;
   color: black;
 }
-body .container section:nth-of-type(3) {
+body .full-width-container section:nth-of-type(3) {
   background-color: #151f2e;
   color: white;
 }
-body .container section:nth-of-type(4) {
+body .full-width-container section:nth-of-type(4) {
   background-color: #ffdd00;
   color: black;
 }


### PR DESCRIPTION
The implementation of container class in tailwind is not supposed to be used in full width blocks as in our use case.

Ref: https://tailwindcss.com/docs/container#header
Fixes #1 